### PR TITLE
useCallback and remove unused vars

### DIFF
--- a/src/components/MemeGenerator.js
+++ b/src/components/MemeGenerator.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Meme from "./Meme";
 
-const MemeGenerator = (props) => {
+const MemeGenerator = () => {
   const [textFieldTop, setTextFieldTop] = useState("");
   const [textFieldBottom, setTextFieldBottom] = useState("");
   const [dataActiveMemes, setDataActiveMemes] = useState([]);
@@ -13,12 +13,12 @@ const MemeGenerator = (props) => {
       .then((response) => setDataMemes(response.data.memes));
   }, []);
 
-  const handleGenerateMeme = (event) => {
-    const entries = [1, 2, 3].map((x) =>
+  const handleGenerateMeme = useCallback(() => {
+    const entries = [1, 2, 3].map(() =>
       Math.floor(Math.random() * dataMemes.length)
     );
     setDataActiveMemes(entries);
-  };
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
Right now the handleGenerateMeme function is recreated on each render which is a waste. If you use `useCallback` with an empty change array, then itll just be created once! Also this is huge when preventing many re-renders if you're passing that callback down to other components. This is because those components that are receiving the function will see a new function everytime and rerender since its changed unless they implement a custom `shouldComponentUpdate` 